### PR TITLE
fix(disable-regions): remove sso users

### DIFF
--- a/Policies/Gov-DisableRegionsPolicy.md
+++ b/Policies/Gov-DisableRegionsPolicy.md
@@ -69,7 +69,6 @@ It should be applied to specific Workload OUs, or on a per-account basis, where 
           "aws:PrincipalArn": [
             "arn:aws:iam::*:role/security-audit",
             "arn:aws:iam::*:role/OrganizationAccountAccessRole",
-            "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO*",
             "arn:aws:iam::*:role/stacksets-exec-*",
             "arn:aws:iam::*:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig"
           ]


### PR DESCRIPTION
## what

- remove sso users from disable-regions policy

## why

- If the intention is to prevent local admins from accessing disabled regions, then we must also remove the `AWSReservedSSO` roles, right?